### PR TITLE
fix: release on refactor commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,26 @@
   "release": {
     "branches": [
       "main"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "type": "refactor",
+              "release": "patch"
+            }
+          ],
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES"
+            ]
+          }
+        }
+      ]
     ]
   }
 }


### PR DESCRIPTION
By default, semantic release does not make a release for refactor commits. We want to have patch releases on refactors.