### PR TITLE
refactor: no files for cert/key

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,25 +14,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
-      - name: Write key and certificate to files
-        env:
-          AZUL_KEY: ${{ secrets.AZUL_KEY }}
-          AZUL_CERT: ${{ secrets.AZUL_CERT }}
-        run: |
-          echo "${AZUL_KEY}" | base64 --decode > ${HOME}/test.key
-          echo "${AZUL_CERT}" | base64 --decode > ${HOME}/test.crt
+          node-version: 'lts/*'
       - run: npm ci
       - name: Run tests
         env:
           AUTH1: ${{ secrets.AUTH1 }}
           AUTH2: ${{ secrets.AUTH2 }}
           MERCHANT_ID: ${{ secrets.MERCHANT_ID }}
+          AZUL_KEY: ${{ secrets.AZUL_KEY }}
+          AZUL_CERT: ${{ secrets.AZUL_CERT }}
         run: |
-          export CERTIFICATE_PATH=${HOME}/test.crt
-          export KEY_PATH=${HOME}/test.key
           npm run test
-      - name: Remove key and certificate
-        run: |
-          rm ${HOME}/test.key
-          rm ${HOME}/test.crt

--- a/src/azul-api/request.ts
+++ b/src/azul-api/request.ts
@@ -1,12 +1,6 @@
-import path from 'path';
-import fs from 'fs/promises';
 import { request, Agent } from 'undici';
 import { capitalizeKeys } from '../utils';
 import { Process } from './processes';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 enum AzulURL {
   DEV = 'https://pruebas.azul.com.do/webservices/JSON/Default.aspx',
@@ -17,8 +11,8 @@ export type Config = {
   auth1: string;
   auth2: string;
   merchantId: string;
-  certificatePath: string;
-  keyPath: string;
+  certificate: string;
+  key: string;
   environment?: 'dev' | 'prod';
   channel?: string;
 };
@@ -30,17 +24,15 @@ class AzulRequester {
   private auth2: string;
   private channel: string;
   private merchantId: string;
-  private certificatePath: string;
-  private keyPath: string;
-  private certificate: Buffer | undefined;
-  private certificateKey: Buffer | undefined;
+  private certificate: string;
+  private key: string;
 
   constructor(config: Config) {
     this.auth1 = config.auth1;
     this.auth2 = config.auth2;
     this.merchantId = config.merchantId;
-    this.certificatePath = config.certificatePath;
-    this.keyPath = config.keyPath;
+    this.certificate = config.certificate;
+    this.key = config.key;
 
     if (config.channel === undefined) {
       this.channel = 'EC';
@@ -89,20 +81,14 @@ class AzulRequester {
     return (await response.body.json()) as any;
   }
 
-  private async getCertificates(): Promise<{ cert: Buffer; key: Buffer }> {
-    if (this.certificate && this.certificateKey) {
-      return {
-        cert: this.certificate,
-        key: this.certificateKey
-      };
+  private async getCertificates(): Promise<{ cert: string; key: string }> {
+    if (!this.certificate || !this.key) {
+      throw new Error('Missing certificate or key');
     }
-
-    this.certificate = await fs.readFile(path.resolve(__dirname, this.certificatePath));
-    this.certificateKey = await fs.readFile(path.resolve(__dirname, this.keyPath));
 
     return {
       cert: this.certificate,
-      key: this.certificateKey
+      key: this.key
     };
   }
 }

--- a/tests/integration/hold.test.ts
+++ b/tests/integration/hold.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from 'crypto';
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, beforeAll, it } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can hold a payment', () => {
   const customOrderId = randomUUID();

--- a/tests/integration/instance.ts
+++ b/tests/integration/instance.ts
@@ -1,0 +1,9 @@
+import AzulAPI from '../../src/azul-api/api';
+
+export const azul = new AzulAPI({
+  auth1: process.env.AUTH1!,
+  auth2: process.env.AUTH2!,
+  merchantId: process.env.MERCHANT_ID!,
+  certificate: process.env.AZUL_CERT!,
+  key: process.env.AZUL_KEY!
+});

--- a/tests/integration/post.test.ts
+++ b/tests/integration/post.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from 'crypto';
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can post a payment', () => {
   it('Can post a hold', async () => {

--- a/tests/integration/refund.test.ts
+++ b/tests/integration/refund.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from 'crypto';
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can refund a payment', () => {
   it('Can refund a sale', async () => {

--- a/tests/integration/sale.test.ts
+++ b/tests/integration/sale.test.ts
@@ -1,14 +1,6 @@
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can make a payment', () => {
   it('Can make a payment', async () => {

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from 'crypto';
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it, beforeAll } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can search a payment', () => {
   const customOrderId = randomUUID();

--- a/tests/integration/vault.test.ts
+++ b/tests/integration/vault.test.ts
@@ -1,14 +1,6 @@
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('DataVault', () => {
   let dataVaultToken: string;

--- a/tests/integration/verify.test.ts
+++ b/tests/integration/verify.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from 'crypto';
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it, beforeAll } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can verify a payment', () => {
   const customOrderId = randomUUID();

--- a/tests/integration/void.test.ts
+++ b/tests/integration/void.test.ts
@@ -1,15 +1,7 @@
 import { randomUUID } from 'crypto';
-import AzulAPI from '../../src/azul-api/api';
+import { azul } from './instance';
 import { describe, expect, it, beforeAll } from 'vitest';
 import 'dotenv/config';
-
-const azul = new AzulAPI({
-  auth1: process.env.AUTH1!,
-  auth2: process.env.AUTH2!,
-  merchantId: process.env.MERCHANT_ID!,
-  certificatePath: process.env.CERTIFICATE_PATH!,
-  keyPath: process.env.KEY_PATH!
-});
 
 describe('Can void a payment', () => {
   const customOrderId = randomUUID();


### PR DESCRIPTION
We are no longer reading from the file system for the cert/key. The cert/key should be passed as string - no extra steps reading from fs.