### PR TITLE
BREAKING CHANGE: Cloudflare Workers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,41 @@ The API does not require a redirection or any sort of form. It straights send yo
 **NOTE: It is heavily recomended to set the `timeout` for this request to at least 120 seconds.**
 
 For more examples, please take a look at our [tests](./tests) and [examples](./examples).
+
+### How to use Undici
+
+```ts
+import { fetch, Agent } from 'undici';
+import { parsePEM } from '@lucrise/azul-ts';
+
+export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
+  const key = parsePEM(input.key, 'key');
+  const cert = parsePEM(input.cert, 'certificate');
+
+  const agent = new Agent({
+    connect: {
+      cert: cert,
+      key: key
+    }
+  });
+
+  return async (input: string, init?: RequestOptions): Promise<unknown> => {
+    const response = await fetch(input, {
+      ...init,
+      dispatcher: agent
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const text = await response.text();
+
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error('Did not receive JSON, instead received: ' + text);
+    }
+  };
+}
+```

--- a/examples/3ds-example.ts
+++ b/examples/3ds-example.ts
@@ -1,8 +1,11 @@
 import express from 'express';
 
 import { env } from '../src/tests/instance';
-import { AzulSecure } from '../src/secure/secure';
+import { undiciFetcher } from './undici-fetcher';
+
 import 'dotenv/config';
+
+import { AzulSecure } from '../src/secure/secure';
 
 const app = express();
 app.use(express.urlencoded({ extended: true }));
@@ -30,10 +33,12 @@ const azul = new AzulSecure({
   auth1: env.AUTH1_3DS,
   auth2: env.AUTH1_3DS,
   merchantId: env.MERCHANT_ID,
-  certificate: env.AZUL_CERT,
-  key: env.AZUL_KEY,
   processMethodBaseUrl: 'http://localhost:3000/process-method',
-  processChallengeBaseUrl: 'http://localhost:3000/process-challenge'
+  processChallengeBaseUrl: 'http://localhost:3000/process-challenge',
+  fetch: undiciFetcher({
+    cert: env.AZUL_CERT,
+    key: env.AZUL_KEY
+  })
 });
 
 app.get('/', (req, res) => {

--- a/examples/api-example.ts
+++ b/examples/api-example.ts
@@ -2,16 +2,20 @@ import express from 'express';
 
 import { Azul } from '../src/api';
 import { env } from '../src/tests/instance';
+
 import 'dotenv/config';
 
+import { undiciFetcher } from './undici-fetcher';
 const app = express();
 
 const azul = new Azul({
   auth1: env.AUTH1,
   auth2: env.AUTH2,
   merchantId: env.MERCHANT_ID,
-  certificate: env.AZUL_CERT,
-  key: env.AZUL_KEY
+  fetch: undiciFetcher({
+    cert: env.AZUL_CERT,
+    key: env.AZUL_KEY
+  })
 });
 
 app.get('/buy', async (req, res) => {

--- a/examples/hold-example.ts
+++ b/examples/hold-example.ts
@@ -4,12 +4,16 @@ import { Azul } from '../src/api';
 import { env } from '../src/tests/instance';
 import 'dotenv/config';
 
+import { undiciFetcher } from './undici-fetcher';
+
 const azul = new Azul({
   auth1: env.AUTH1,
   auth2: env.AUTH2,
   merchantId: env.MERCHANT_ID,
-  certificate: env.AZUL_CERT,
-  key: env.AZUL_KEY
+  fetch: undiciFetcher({
+    cert: env.AZUL_CERT,
+    key: env.AZUL_KEY
+  })
 });
 
 const amount = 100; // RD$100

--- a/examples/simple-example.ts
+++ b/examples/simple-example.ts
@@ -5,8 +5,7 @@ const azul = new Azul({
   auth1: env.AUTH1,
   auth2: env.AUTH2,
   merchantId: env.MERCHANT_ID,
-  certificate: env.AZUL_CERT,
-  key: env.AZUL_KEY
+  fetch: fetch
 });
 
 const result = await azul.sale({

--- a/examples/undici-fetcher.ts
+++ b/examples/undici-fetcher.ts
@@ -1,26 +1,7 @@
-import { z } from 'zod';
-import { config } from 'dotenv';
-
-import { Azul } from '../api';
-
-config();
-
-const envSchema = z.object({
-  AUTH1: z.string(),
-  AUTH2: z.string(),
-  AUTH1_3DS: z.string(),
-  AUTH2_3DS: z.string(),
-  MERCHANT_ID: z.string(),
-  AZUL_CERT: z.string(),
-  AZUL_KEY: z.string()
-});
-
-export const env = envSchema.parse(process.env);
-
 import { fetch, Agent } from 'undici';
 
-import { Fetcher, RequestOptions } from '../fetch';
-import { parsePEM } from '../parse-certificate/parse-certificate';
+import { Fetcher, RequestOptions } from '../src/fetch';
+import { parsePEM } from '../src/parse-certificate/parse-certificate';
 
 export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
   const key = parsePEM(input.key, 'key');
@@ -52,13 +33,3 @@ export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
     }
   };
 }
-
-export const azul = new Azul({
-  auth1: env.AUTH1,
-  auth2: env.AUTH2,
-  merchantId: env.MERCHANT_ID,
-  fetch: undiciFetcher({
-    cert: env.AZUL_CERT,
-    key: env.AZUL_KEY
-  })
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "undici": "^7.8.0",
         "zod": "^3.23.5"
       },
       "devDependencies": {
@@ -10357,15 +10356,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
-      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "tsc-alias": "^1.8.8",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.19.0",
+        "undici": "^7.8.0",
         "vitest": "^1.6.0"
       }
     },
@@ -10356,6 +10357,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "undici": "^7.8.0",
         "zod": "^3.23.5"
       },
       "devDependencies": {
@@ -10356,6 +10357,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "undici": "^6.15.0",
         "zod": "^3.23.5"
       },
       "devDependencies": {
@@ -10357,15 +10356,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "undici": "^7.8.0",
     "zod": "^3.23.5"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "undici": "^6.15.0",
     "zod": "^3.23.5"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "undici": "^7.8.0",
     "zod": "^3.23.5"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "tsc-alias": "^1.8.8",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.19.0",
+    "undici": "^7.8.0",
     "vitest": "^1.6.0"
   },
   "dependencies": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,6 @@ import AzulRequester, { Config } from './request';
 import { VerifyResponse } from './verify/schemas';
 import { SaleRequest, SaleResponse } from './sale/schemas';
 import { SearchRequest, SearchResponse } from './search/schemas';
-import { parsePEM } from './parse-certificate/parse-certificate';
 import { RefundRequestInput, RefundResponse } from './refund/schemas';
 
 export class Azul extends EventEmitter {
@@ -22,8 +21,6 @@ export class Azul extends EventEmitter {
 
   constructor(config: Config) {
     super();
-    config.key = parsePEM(config.key, 'key');
-    config.certificate = parsePEM(config.certificate, 'certificate');
 
     this.requester = new AzulRequester(config, this);
     this.vault = new DataVault(this.requester);

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,0 +1,62 @@
+import { fetch, Agent } from 'undici';
+
+import { parsePEM } from './parse-certificate/parse-certificate';
+
+type RequestOptions = {
+  method: string;
+  headers: HeadersInit;
+  body: string;
+};
+
+export type Fetcher = (input: string, init?: RequestOptions) => Promise<unknown>;
+
+export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
+  const key = parsePEM(input.key, 'key');
+  const cert = parsePEM(input.cert, 'certificate');
+
+  const agent = new Agent({
+    connect: {
+      cert: cert,
+      key: key
+    }
+  });
+
+  return async (input: string, init?: RequestOptions): Promise<unknown> => {
+    const response = await fetch(input, {
+      ...init,
+      dispatcher: agent
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const text = await response.text();
+
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error('Did not receive JSON, instead received: ' + text);
+    }
+  };
+}
+
+type NativeFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export function workerFetcher(fetch: NativeFetch): Fetcher {
+  return async (url: string, init?: RequestOptions): Promise<unknown> => {
+    const response = await fetch(url, init);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const text = await response.text();
+
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error('Did not receive JSON, instead received: ' + text);
+    }
+  };
+}

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,39 +1,4 @@
-// import { fetch, Agent } from 'undici';
-
-// import { parsePEM } from './parse-certificate/parse-certificate';
-
-// export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
-//   const key = parsePEM(input.key, 'key');
-//   const cert = parsePEM(input.cert, 'certificate');
-
-//   const agent = new Agent({
-//     connect: {
-//       cert: cert,
-//       key: key
-//     }
-//   });
-
-//   return async (input: string, init?: RequestOptions): Promise<unknown> => {
-//     const response = await fetch(input, {
-//       ...init,
-//       dispatcher: agent
-//     });
-
-//     if (!response.ok) {
-//       throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const text = await response.text();
-
-//     try {
-//       return JSON.parse(text);
-//     } catch {
-//       throw new Error('Did not receive JSON, instead received: ' + text);
-//     }
-//   };
-// }
-
-type RequestOptions = {
+export type RequestOptions = {
   method: string;
   headers: HeadersInit;
   body: string;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,3 +1,38 @@
+// import { fetch, Agent } from 'undici';
+
+// import { parsePEM } from './parse-certificate/parse-certificate';
+
+// export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
+//   const key = parsePEM(input.key, 'key');
+//   const cert = parsePEM(input.cert, 'certificate');
+
+//   const agent = new Agent({
+//     connect: {
+//       cert: cert,
+//       key: key
+//     }
+//   });
+
+//   return async (input: string, init?: RequestOptions): Promise<unknown> => {
+//     const response = await fetch(input, {
+//       ...init,
+//       dispatcher: agent
+//     });
+
+//     if (!response.ok) {
+//       throw new Error(`HTTP error! status: ${response.status}`);
+//     }
+
+//     const text = await response.text();
+
+//     try {
+//       return JSON.parse(text);
+//     } catch {
+//       throw new Error('Did not receive JSON, instead received: ' + text);
+//     }
+//   };
+// }
+
 type RequestOptions = {
   method: string;
   headers: HeadersInit;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,7 +1,3 @@
-import { fetch, Agent } from 'undici';
-
-import { parsePEM } from './parse-certificate/parse-certificate';
-
 type RequestOptions = {
   method: string;
   headers: HeadersInit;
@@ -9,37 +5,6 @@ type RequestOptions = {
 };
 
 export type Fetcher = (input: string, init?: RequestOptions) => Promise<unknown>;
-
-export function undiciFetcher(input: { cert: string; key: string }): Fetcher {
-  const key = parsePEM(input.key, 'key');
-  const cert = parsePEM(input.cert, 'certificate');
-
-  const agent = new Agent({
-    connect: {
-      cert: cert,
-      key: key
-    }
-  });
-
-  return async (input: string, init?: RequestOptions): Promise<unknown> => {
-    const response = await fetch(input, {
-      ...init,
-      dispatcher: agent
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const text = await response.text();
-
-    try {
-      return JSON.parse(text);
-    } catch {
-      throw new Error('Did not receive JSON, instead received: ' + text);
-    }
-  };
-}
 
 type NativeFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ import { AzulSecure } from './secure/secure';
 
 export type { Storage };
 export { Azul, AzulSecure };
+export { parsePEM } from './parse-certificate/parse-certificate';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ import { AzulSecure } from './secure/secure';
 
 export type { Storage };
 export { Azul, AzulSecure };
-export { parsePEM } from './parse-certificate/parse-certificate';
+export { undiciFetcher, workerFetcher } from './fetch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,6 @@ import { AzulSecure } from './secure/secure';
 
 export type { Storage };
 export { Azul, AzulSecure };
-export { undiciFetcher, workerFetcher } from './fetch';
+export { parsePEM } from './parse-certificate/parse-certificate';
+export { workerFetcher } from './fetch';
+export type { Fetcher } from './fetch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export type { Storage };
 export { Azul, AzulSecure };
 export { parsePEM } from './parse-certificate/parse-certificate';
 export { workerFetcher } from './fetch';
-export type { Fetcher } from './fetch';
+export type { Fetcher, RequestOptions } from './fetch';

--- a/src/tests/instance.ts
+++ b/src/tests/instance.ts
@@ -20,5 +20,6 @@ export const env = envSchema.parse(process.env);
 export const azul = new Azul({
   auth1: env.AUTH1,
   auth2: env.AUTH2,
-  merchantId: env.MERCHANT_ID
+  merchantId: env.MERCHANT_ID,
+  fetch: fetch
 });

--- a/src/tests/instance.ts
+++ b/src/tests/instance.ts
@@ -20,7 +20,5 @@ export const env = envSchema.parse(process.env);
 export const azul = new Azul({
   auth1: env.AUTH1,
   auth2: env.AUTH2,
-  merchantId: env.MERCHANT_ID,
-  certificate: env.AZUL_CERT,
-  key: env.AZUL_KEY
+  merchantId: env.MERCHANT_ID
 });


### PR DESCRIPTION
This change strips out `undici` as a dependency and accepts a custom fetch implementation. This allows anyone to use either undici or native fetch.