### PR TITLE
BREAKING CHANGE: configuration changes & ForceNo3DS

### DIFF
--- a/src/sale/schemas.ts
+++ b/src/sale/schemas.ts
@@ -8,7 +8,8 @@ import {
   customOrderId,
   expiration,
   posInputMode,
-  saveToDataVault
+  saveToDataVault,
+  forceNo3DS
 } from '../schemas';
 
 // Sale Request
@@ -21,7 +22,8 @@ export const cardPaymentSchema = z.object({
   expiration,
   CVC,
   posInputMode,
-  saveToDataVault
+  saveToDataVault,
+  forceNo3DS
 });
 
 export const tokenPaymentSchema = z.object({
@@ -31,7 +33,8 @@ export const tokenPaymentSchema = z.object({
   ITBIS,
   dataVaultToken: z.string().max(36),
   posInputMode,
-  expiration: z.literal('').default('')
+  expiration: z.literal('').default(''),
+  forceNo3DS
 });
 
 export const saleRequestSchema = z.union([cardPaymentSchema, tokenPaymentSchema]);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -13,4 +13,4 @@ export const customerServicePhone = z.string().max(32);
 export const ECommerceURL = z.string().max(32);
 export const customOrderId = z.string().max(75).optional();
 export const saveToDataVault = z.enum(['1', '2']).optional();
-export const forceNo3DS = z.enum(['0', '1']);
+export const forceNo3DS = z.boolean();

--- a/src/secure/sale.ts
+++ b/src/secure/sale.ts
@@ -52,7 +52,7 @@ export async function secureSale({
     url: requester.url,
     body: {
       ...secureSaleRequestSchema.parse(input),
-      ForceNo3DS: '0',
+      ForceNo3DS: input.forceNo3DS ? '1' : '0',
       TrxType: 'Sale'
     }
   });


### PR DESCRIPTION
This PR will trigger a release that introduces significant updates, including breaking changes to configuration and 3DS handling, new features, and several refactorings and fixes to improve consistency and functionality.

## ⚠️ Breaking Changes

1.  **Configuration Object Updates:**
    *   The `Config` type (from `src/request.ts`) has been renamed to `Configuration`.
        *   The `channel` property within `Configuration` is now **mandatory**.
        *   The `environment` property type (`'development'` | `'production'`) is now explicitly part of the `Configuration` type.
    *   The `SecureConfig` type (from `src/secure/secure.ts`) has been renamed to `SecureConfiguration`.
        *   In `SecureConfiguration`, `processMethodBaseUrl` has been renamed to `processMethodURL`.
        *   In `SecureConfiguration`, `processChallengeBaseUrl` has been renamed to `processChallengeURL`.
        *   The `storage` property in `SecureConfiguration` is now **mandatory**.

2.  **Constructor Initialization:**
    *   The `Azul` class constructor (`src/api.ts`) now expects a `Configuration` object.
    *   The `AzulSecure` class constructor (`src/secure/secure.ts`) now expects a `SecureConfiguration` object. It no longer defaults the `storage` property, as it is now mandatory.

3.  **`forceNo3DS` Parameter Type:**
    *   The `forceNo3DS` property in various schemas (e.g., `src/schemas.ts`, `src/sale/schemas.ts`) now uses a `boolean` type (`true`/`false`) instead of an enum (`'0'`/`'1'`). The library internally maps this boolean to the required string values for API requests.

4.  **`AzulSecure.secureSale()` Method and 3DS Form Handling:**
    *   The `secureSale` method in `AzulSecure` (`src/secure/secure.ts`) no longer returns an HTML `form` string directly within its response for 3DS challenge or method flows.
    *   To get the HTML form for 3DS, you must now call the new public methods:
        *   `azulSecure.generateChallengeForm({ response, secureId })` if `secureSale` response `type` is `'challenge'`.
        *   `azulSecure.generateMethodForm(response)` if `secureSale` response `type` is `'method'`.
    *   The internal method `generateThreeDSChallengeResponseForm` has been renamed to `generateChallengeForm` and is now public.

5.  **Internal Function Renaming:**
    *   `processThreeDSChallengeInternal` (in `src/secure/challenge.ts`) is now `processThreeDSChallenge`.
    *   `processThreeDSMethodInternal` (in `src/secure/method.ts`) is now `processThreeDSMethod`.

6.  **Schema Change for `threeDSMethodResponseSchema`:**
    *   The `threeDSMethodResponseSchema` (in `src/secure/schemas.ts`) no longer includes a `form` property in its transformed output. This is now handled by the `generateMethodForm` method.

## ✨ New Features

*   Added `environment` and `channel` properties to `Azul` instances in example files, aligning with the new mandatory configuration fields. (175b519)

## 🔄 Refactorings

*   Exported the `SecureSaleResponse` type and streamlined 3DS method response handling. (204b4cb)
*   Consistently renamed internal 3DS processing functions: `processThreeDSChallengeInternal` to `processThreeDSChallenge` and `processThreeDSMethodInternal` to `processThreeDSMethod`. (6e4c88b)
*   Reorganized imports and updated the `SecureConfiguration` type for improved clarity. (9782612)
*   Renamed URL configuration properties for 3DS processing: `processMethodBaseUrl` to `processMethodURL` and `processChallengeBaseUrl` to `processChallengeURL` for consistency. (467d48d)
*   Standardized type naming: `SecureConfig` is now `SecureConfiguration`. (27699a6)
*   Utilized the `MethodNotificationStatus` enum within `processThreeDSMethod` for better type safety and consistency. (9767c42)
*   Improved import organization within the `data-vault` module. (6dce68c)
*   Standardized type naming: `Config` is now `Configuration`. (a2646e1)

## 🐛 Fixes

*   Added the `CHANNEL` property to the environment variable schema and `Azul` instance configurations, ensuring it's correctly processed. (ec42fc0)
*   Updated and corrected examples to reflect recent changes. (568e345)
